### PR TITLE
Add new `no-focused-tests` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Then configure the rules you want to use under the rules section.
 ### Supported Rules
 
 - No Skipped tests
+- No Focused tests
 - Lower case title
 - Max number of nested describe blocks
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import maxNestedDescribe, {RULE_NAME as maxNestedDescribeName} from "./rules/max
 import noConditionalInTest, {RULE_NAME as noConditionalInTestName} from "./rules/no-conditional-in-tests";
 import noIdenticalTitle, {RULE_NAME as noIdenticalTitleName} from "./rules/no-identical-title";
 import noSkippedTests, {RULE_NAME as noSkippedTestsName} from "./rules/no-skipped-tests";
+import noFocusedTests, {RULE_NAME as noFocusedTestsName} from "./rules/no-focused-tests";
 
 export default {
   rules: {
@@ -13,5 +14,6 @@ export default {
     [maxNestedDescribeName]: maxNestedDescribe,
     [noIdenticalTitleName]: noIdenticalTitle,
     [noConditionalInTestName]: noConditionalInTest,
+    [noFocusedTestsName]: noFocusedTests,
   },
 };

--- a/src/rules/no-focused-tests.test.ts
+++ b/src/rules/no-focused-tests.test.ts
@@ -1,0 +1,27 @@
+import { RuleTester } from "@typescript-eslint/utils/dist/ts-eslint";
+import { it } from "vitest";
+import rule, { RULE_NAME } from "./no-focused-tests";
+
+const valids = [
+  `it("test", () => {});`,
+  `describe("test group", () => {});`
+];
+
+const invalids = [
+  `it.only("test", () => {});`,
+  `describe.only("test", () => {});`
+];
+
+it(RULE_NAME, () => {
+  const ruleTester: RuleTester = new RuleTester({
+    parser: require.resolve("@typescript-eslint/parser"),
+  });
+  ruleTester.run(RULE_NAME, rule, {
+    valid: valids,
+    invalid: invalids.map((i) => ({
+      code: i,
+      output: i.trim(),
+      errors: [{ messageId: "noFocusedTests" }],
+    })),
+  });
+});

--- a/src/rules/no-focused-tests.ts
+++ b/src/rules/no-focused-tests.ts
@@ -1,0 +1,43 @@
+import { createEslintRule } from "../utils";
+
+export type MessageIds = "noFocusedTests";
+export const RULE_NAME = "no-focused-tests";
+export type Options = [];
+
+export default createEslintRule<Options, MessageIds>({
+  name: RULE_NAME,
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Disallow focused tests",
+      recommended: "error",
+    },
+    fixable: "code",
+    schema: [],
+    messages: {
+        noFocusedTests: "Focused tests are not allowed.",
+    },
+  },
+  defaultOptions: [],
+  create: (context) => {
+    return {
+      ExpressionStatement(node) {
+        if (node.expression.type === "CallExpression") {
+          const { callee } = node.expression;
+          if (
+            callee.type === "MemberExpression" &&
+            callee.object.type === "Identifier" &&
+            (callee.object.name === "it" || callee.object.name === "describe") &&
+            callee.property.type === "Identifier" &&
+            callee.property.name === "only"
+          ) {
+            context.report({
+              node,
+              messageId: "noFocusedTests",
+            });
+          }
+        }
+      },
+    };
+  },
+});


### PR DESCRIPTION
This PR fixes/implements the following **bugs/features**

* [ ] Bug
* [x] Feature
* [ ] Breaking changes

---

Adds a new `no-focused-tests` rule (similar to [Jest's](https://github.com/jest-community/eslint-plugin-jest/blob/main/src/rules/no-focused-tests.ts)). It's essentially a copy/paste of the `no-skipped-tests` rule, but it looks for `.only` instead of `.skip`.
