### PR TITLE
feat: highlight only keyword in no-focused-tests rule

### DIFF
--- a/src/rules/no-focused-tests.test.ts
+++ b/src/rules/no-focused-tests.test.ts
@@ -2,26 +2,37 @@ import { RuleTester } from "@typescript-eslint/utils/dist/ts-eslint";
 import { it } from "vitest";
 import rule, { RULE_NAME } from "./no-focused-tests";
 
-const valids = [
-  `it("test", () => {});`,
-  `describe("test group", () => {});`
-];
-
-const invalids = [
-  `it.only("test", () => {});`,
-  `describe.only("test", () => {});`
-];
-
 it(RULE_NAME, () => {
   const ruleTester: RuleTester = new RuleTester({
     parser: require.resolve("@typescript-eslint/parser"),
   });
+
   ruleTester.run(RULE_NAME, rule, {
-    valid: valids,
-    invalid: invalids.map((i) => ({
-      code: i,
-      output: i.trim(),
-      errors: [{ messageId: "noFocusedTests" }],
-    })),
+    valid: [
+      `it("test", () => {});`,
+      `describe("test group", () => {});`
+    ],
+
+    invalid: [{
+      code: `it.only("test", () => {});`,
+      errors: [{
+        column: 4,
+        endColumn: 8,
+        endLine: 1,
+        line: 1,
+        messageId: "noFocusedTests"
+      }],
+      output: `it.only("test", () => {});`,
+    }, {
+      code: `describe.only("test", () => {});`,
+      errors: [{
+        column: 10,
+        endColumn: 14,
+        endLine: 1,
+        line: 1,
+        messageId: "noFocusedTests"
+      }],
+      output: `describe.only("test", () => {});`,
+    }]
   });
 });

--- a/src/rules/no-focused-tests.ts
+++ b/src/rules/no-focused-tests.ts
@@ -32,7 +32,7 @@ export default createEslintRule<Options, MessageIds>({
             callee.property.name === "only"
           ) {
             context.report({
-              node,
+              node: callee.property,
               messageId: "noFocusedTests",
             });
           }


### PR DESCRIPTION
This PR fixes/implements the following **bugs/features**

* [ ] Bug
* [x] Feature
* [ ] Breaking changes

**Closing issues**

Addresses this comment https://github.com/veritem/eslint-plugin-vitest/pull/9#issuecomment-1359371437

The user has correctly reported that the current `no-focused-tests` rule is highlighting the entire test case as a failure. After this PR only the `only` keyword will be highlighted as a failure.

Also updates the unit test to capture this requirement.