### PR TITLE
docs: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ To use the all configuration, extend it in your `.eslintrc` file:
 | [no-conditional-in-test](docs/rules/no-conditional-in-test.md)               | Disallow conditional tests                                               | 🌐 |    |    |
 | [no-conditional-tests](docs/rules/no-conditional-tests.md)                   | Disallow conditional tests                                               | 🌐 |    |    |
 | [no-disabled-tests](docs/rules/no-disabled-tests.md)                         | Disallow disabled tests                                                  | 🌐 |    |    |
-| [no-done-callback](docs/rules/no-done-callback.md)                           | Disallow using a callback in asynchrounous tests and hooks               | 🌐 |    | 💡 |
+| [no-done-callback](docs/rules/no-done-callback.md)                           | Disallow using a callback in asynchronous tests and hooks                | 🌐 |    | 💡 |
 | [no-duplicate-hooks](docs/rules/no-duplicate-hooks.md)                       | Disallow duplicate hooks and teardown hooks                              | 🌐 |    |    |
 | [no-focused-tests](docs/rules/no-focused-tests.md)                           | Disallow focused tests                                                   | 🌐 | 🔧 |    |
 | [no-hooks](docs/rules/no-hooks.md)                                           | Disallow setup and teardown hooks                                        | 🌐 |    |    |

--- a/src/rules/no-done-callback.ts
+++ b/src/rules/no-done-callback.ts
@@ -26,7 +26,7 @@ export default createEslintRule<Options, MessageIds>({
 	meta: {
 		type: 'suggestion',
 		docs: {
-			description: 'Disallow using a callback in asynchrounous tests and hooks',
+			description: 'Disallow using a callback in asynchronous tests and hooks',
 			recommended: 'error'
 		},
 		schema: [],


### PR DESCRIPTION
follow up #155

The following error was shown when running `pnpm lint`:

> Please run eslint-doc-generator. A rule doc is out-of-date: docs\rules\no-done-callback.md

