### PR TITLE
Small no-focussed-tests updates

### DIFF
--- a/src/rules/no-focused-tests.test.ts
+++ b/src/rules/no-focused-tests.test.ts
@@ -5,7 +5,7 @@ import rule, { RULE_NAME } from './no-focused-tests'
 it(RULE_NAME, () => {
   const ruleTester: RuleTester = new RuleTester({
     parser: require.resolve('@typescript-eslint/parser')
-  })
+  });
 
   ruleTester.run(RULE_NAME, rule, {
     valid: ['it("test", () => {});', 'describe("test group", () => {});'],
@@ -36,6 +36,19 @@ it(RULE_NAME, () => {
           }
         ],
         output: 'describe.only("test", () => {});'
+      },
+      {
+        code: 'test.only("test", () => {});',
+        errors: [
+          {
+            column: 6,
+            endColumn: 10,
+            endLine: 1,
+            line: 1,
+            messageId: 'noFocusedTests'
+          }
+        ],
+        output: 'test.only("test", () => {});',
       },
       {
         code: 'it.only.each([])("test", () => {});',

--- a/src/rules/no-focused-tests.test.ts
+++ b/src/rules/no-focused-tests.test.ts
@@ -3,40 +3,53 @@ import { it } from 'vitest'
 import rule, { RULE_NAME } from './no-focused-tests'
 
 it(RULE_NAME, () => {
-	const ruleTester: RuleTester = new RuleTester({
-		parser: require.resolve('@typescript-eslint/parser')
-	})
+  const ruleTester: RuleTester = new RuleTester({
+    parser: require.resolve('@typescript-eslint/parser')
+  })
 
-	ruleTester.run(RULE_NAME, rule, {
-		valid: ['it("test", () => {});', 'describe("test group", () => {});'],
+  ruleTester.run(RULE_NAME, rule, {
+    valid: ['it("test", () => {});', 'describe("test group", () => {});'],
 
-		invalid: [
-			{
-				code: 'it.only("test", () => {});',
-				errors: [
-					{
-						column: 4,
-						endColumn: 8,
-						endLine: 1,
-						line: 1,
-						messageId: 'noFocusedTests'
-					}
-				],
-				output: 'it.only("test", () => {});'
-			},
-			{
-				code: 'describe.only("test", () => {});',
-				errors: [
-					{
-						column: 10,
-						endColumn: 14,
-						endLine: 1,
-						line: 1,
-						messageId: 'noFocusedTests'
-					}
-				],
-				output: 'describe.only("test", () => {});'
-			}
-		]
-	})
+    invalid: [
+      {
+        code: 'it.only("test", () => {});',
+        errors: [
+          {
+            column: 4,
+            endColumn: 8,
+            endLine: 1,
+            line: 1,
+            messageId: 'noFocusedTests'
+          }
+        ],
+        output: 'it.only("test", () => {});'
+      },
+      {
+        code: 'describe.only("test", () => {});',
+        errors: [
+          {
+            column: 10,
+            endColumn: 14,
+            endLine: 1,
+            line: 1,
+            messageId: 'noFocusedTests'
+          }
+        ],
+        output: 'describe.only("test", () => {});'
+      },
+      {
+        code: 'it.only.each([])("test", () => {});',
+        errors: [
+          {
+            column: 4,
+            endColumn: 8,
+            endLine: 1,
+            line: 1,
+            messageId: 'noFocusedTests',
+          },
+        ],
+        output: 'it.only.each([])("test", () => {});',
+      }
+    ]
+  })
 })

--- a/src/rules/no-focused-tests.test.ts
+++ b/src/rules/no-focused-tests.test.ts
@@ -3,66 +3,66 @@ import { it } from 'vitest'
 import rule, { RULE_NAME } from './no-focused-tests'
 
 it(RULE_NAME, () => {
-  const ruleTester: RuleTester = new RuleTester({
-    parser: require.resolve('@typescript-eslint/parser')
-  });
+	const ruleTester: RuleTester = new RuleTester({
+		parser: require.resolve('@typescript-eslint/parser')
+	})
 
-  ruleTester.run(RULE_NAME, rule, {
-    valid: ['it("test", () => {});', 'describe("test group", () => {});'],
+	ruleTester.run(RULE_NAME, rule, {
+		valid: ['it("test", () => {});', 'describe("test group", () => {});'],
 
-    invalid: [
-      {
-        code: 'it.only("test", () => {});',
-        errors: [
-          {
-            column: 4,
-            endColumn: 8,
-            endLine: 1,
-            line: 1,
-            messageId: 'noFocusedTests'
-          }
-        ],
-        output: 'it.only("test", () => {});'
-      },
-      {
-        code: 'describe.only("test", () => {});',
-        errors: [
-          {
-            column: 10,
-            endColumn: 14,
-            endLine: 1,
-            line: 1,
-            messageId: 'noFocusedTests'
-          }
-        ],
-        output: 'describe.only("test", () => {});'
-      },
-      {
-        code: 'test.only("test", () => {});',
-        errors: [
-          {
-            column: 6,
-            endColumn: 10,
-            endLine: 1,
-            line: 1,
-            messageId: 'noFocusedTests'
-          }
-        ],
-        output: 'test.only("test", () => {});',
-      },
-      {
-        code: 'it.only.each([])("test", () => {});',
-        errors: [
-          {
-            column: 4,
-            endColumn: 8,
-            endLine: 1,
-            line: 1,
-            messageId: 'noFocusedTests',
-          },
-        ],
-        output: 'it.only.each([])("test", () => {});',
-      }
-    ]
-  })
+		invalid: [
+			{
+				code: 'it.only("test", () => {});',
+				errors: [
+					{
+						column: 4,
+						endColumn: 8,
+						endLine: 1,
+						line: 1,
+						messageId: 'noFocusedTests'
+					}
+				],
+				output: 'it.only("test", () => {});'
+			},
+			{
+				code: 'describe.only("test", () => {});',
+				errors: [
+					{
+						column: 10,
+						endColumn: 14,
+						endLine: 1,
+						line: 1,
+						messageId: 'noFocusedTests'
+					}
+				],
+				output: 'describe.only("test", () => {});'
+			},
+			{
+				code: 'test.only("test", () => {});',
+				errors: [
+					{
+						column: 6,
+						endColumn: 10,
+						endLine: 1,
+						line: 1,
+						messageId: 'noFocusedTests'
+					}
+				],
+				output: 'test.only("test", () => {});',
+			},
+			{
+				code: 'it.only.each([])("test", () => {});',
+				errors: [
+					{
+						column: 4,
+						endColumn: 8,
+						endLine: 1,
+						line: 1,
+						messageId: 'noFocusedTests',
+					},
+				],
+				output: 'it.only.each([])("test", () => {});',
+			}
+		]
+	})
 })

--- a/src/rules/no-focused-tests.ts
+++ b/src/rules/no-focused-tests.ts
@@ -1,69 +1,69 @@
 import { createEslintRule } from '../utils'
 import { TSESTree } from '@typescript-eslint/utils'
 
-export type MessageIds = 'noFocusedTests'
+export type MessageIds = 'noFocusedTests';
 export const RULE_NAME = 'no-focused-tests'
 export type Options = [];
 
 const isTestOrDescribe = (node: TSESTree.Expression) => {
-  return node.type === 'Identifier' && ['it', 'test', 'describe'].includes(node.name)
+	return node.type === 'Identifier' && ['it', 'test', 'describe'].includes(node.name)
 }
 
 const isOnly = (node: TSESTree.Expression|TSESTree.PrivateIdentifier) => {
-  return node.type === 'Identifier' && node.name === 'only'
+	return node.type === 'Identifier' && node.name === 'only'
 }
 
 export default createEslintRule<Options, MessageIds>({
-  name: RULE_NAME,
-  meta: {
-    type: 'problem',
-    docs: {
-      description: 'Disallow focused tests',
-      recommended: 'error'
-    },
-    fixable: 'code',
-    schema: [],
-    messages: {
-      noFocusedTests: 'Focused tests are not allowed.'
-    }
-  },
-  defaultOptions: [],
-  create: (context) => {
-    return {
-      ExpressionStatement(node) {
-        if (node.expression.type === 'CallExpression') {
-          const { callee } = node.expression
-          if (
-            callee.type === 'MemberExpression' &&
-            isTestOrDescribe(callee.object) &&
-            isOnly(callee.property)
-          ) {
-            context.report({
-              node: callee.property,
-              messageId: 'noFocusedTests'
-            })
-          }
-        }
-      },
-      CallExpression(node) {
-        if (node.callee.type === "CallExpression") {
-          const { callee } = node.callee;
+	name: RULE_NAME,
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Disallow focused tests',
+			recommended: 'error'
+		},
+		fixable: 'code',
+		schema: [],
+		messages: {
+			noFocusedTests: 'Focused tests are not allowed.'
+		}
+	},
+	defaultOptions: [],
+	create: (context) => {
+		return {
+			ExpressionStatement(node) {
+				if (node.expression.type === 'CallExpression') {
+					const { callee } = node.expression
+					if (
+						callee.type === 'MemberExpression' &&
+						isTestOrDescribe(callee.object) &&
+						isOnly(callee.property)
+					) {
+						context.report({
+							node: callee.property,
+							messageId: 'noFocusedTests'
+						})
+					}
+				}
+			},
+			CallExpression(node) {
+				if (node.callee.type === "CallExpression") {
+					const { callee } = node.callee;
 
-          if (
-            callee.type === 'MemberExpression' &&
-            callee.object.type === 'MemberExpression' &&
-            isTestOrDescribe(callee.object.object) &&
-            isOnly(callee.object.property) &&
-            callee.property.type === 'Identifier' &&
-            callee.property.name === 'each'
-          ) {
-            context.report({
-              node: callee.object.property,
-              messageId: 'noFocusedTests'
-            })
-          }
-        }
-      }
-    }
-  }
+					if (
+						callee.type === 'MemberExpression' &&
+						callee.object.type === 'MemberExpression' &&
+						isTestOrDescribe(callee.object.object) &&
+						isOnly(callee.object.property) &&
+						callee.property.type === 'Identifier' &&
+						callee.property.name === 'each'
+					) {
+						context.report({
+							node: callee.object.property,
+							messageId: 'noFocusedTests'
+						})
+					}
+				}
+			}
+		}
+	}
 })

--- a/src/rules/no-focused-tests.ts
+++ b/src/rules/no-focused-tests.ts
@@ -1,44 +1,65 @@
 import { createEslintRule } from '../utils'
 
-export type MessageIds = 'noFocusedTests';
+export type MessageIds = 'noFocusedTests'
 export const RULE_NAME = 'no-focused-tests'
 export type Options = [];
 
 export default createEslintRule<Options, MessageIds>({
-	name: RULE_NAME,
-	meta: {
-		type: 'problem',
-		docs: {
-			description: 'Disallow focused tests',
-			recommended: 'error'
-		},
-		fixable: 'code',
-		schema: [],
-		messages: {
-			noFocusedTests: 'Focused tests are not allowed.'
-		}
-	},
-	defaultOptions: [],
-	create: (context) => {
-		return {
-			ExpressionStatement(node) {
-				if (node.expression.type === 'CallExpression') {
-					const { callee } = node.expression
-					if (
-						callee.type === 'MemberExpression' &&
+  name: RULE_NAME,
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow focused tests',
+      recommended: 'error'
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      noFocusedTests: 'Focused tests are not allowed.'
+    }
+  },
+  defaultOptions: [],
+  create: (context) => {
+    return {
+      ExpressionStatement(node) {
+        if (node.expression.type === 'CallExpression') {
+          const { callee } = node.expression
+          if (
+            callee.type === 'MemberExpression' &&
             callee.object.type === 'Identifier' &&
             (callee.object.name === 'it' ||
               callee.object.name === 'describe') &&
             callee.property.type === 'Identifier' &&
             callee.property.name === 'only'
-					) {
-						context.report({
-							node: callee.property,
-							messageId: 'noFocusedTests'
-						})
-					}
-				}
-			}
-		}
-	}
+          ) {
+            context.report({
+              node: callee.property,
+              messageId: 'noFocusedTests'
+            })
+          }
+
+          if (callee.type !== 'CallExpression') return;
+
+          const subCallee = callee.callee
+
+          if (
+            subCallee.type === 'MemberExpression' &&
+            subCallee.object.type === 'MemberExpression' &&
+            subCallee.object.object.type === 'Identifier' &&
+            (subCallee.object.object.name === 'it' ||
+              subCallee.object.object.name === 'describe') &&
+            subCallee.object.property.type === 'Identifier' &&
+            subCallee.object.property.name === 'only' &&
+            subCallee.property.type === 'Identifier' &&
+            subCallee.property.name === 'each'
+          ) {
+            context.report({
+              node: subCallee.object.property,
+              messageId: 'noFocusedTests'
+            })
+          }
+        }
+      }
+    }
+  }
 })

--- a/src/rules/no-focused-tests.ts
+++ b/src/rules/no-focused-tests.ts
@@ -43,21 +43,22 @@ export default createEslintRule<Options, MessageIds>({
               messageId: 'noFocusedTests'
             })
           }
-
-          if (callee.type !== 'CallExpression') return;
-
-          const subCallee = callee.callee
+        }
+      },
+      CallExpression(node) {
+        if (node.callee.type === "CallExpression") {
+          const { callee } = node.callee;
 
           if (
-            subCallee.type === 'MemberExpression' &&
-            subCallee.object.type === 'MemberExpression' &&
-            isTestOrDescribe(subCallee.object.object) &&
-            isOnly(subCallee.object.property) &&
-            subCallee.property.type === 'Identifier' &&
-            subCallee.property.name === 'each'
+            callee.type === 'MemberExpression' &&
+            callee.object.type === 'MemberExpression' &&
+            isTestOrDescribe(callee.object.object) &&
+            isOnly(callee.object.property) &&
+            callee.property.type === 'Identifier' &&
+            callee.property.name === 'each'
           ) {
             context.report({
-              node: subCallee.object.property,
+              node: callee.object.property,
               messageId: 'noFocusedTests'
             })
           }


### PR DESCRIPTION
This PR enhances no-focussed-tests a bit.

I noticed the `no-focused-tests` rule doesn't apply if you have an `only` on an `it.each`. This adds a check to report an error if an `it.only.each` or `describe.only.each` is encountered.

I also noticed this rule will report on `it.only` and `describe.only`, but not `test.only`, so I added an extra check for that. 

I love this plugin, thanks for the hard work!