### PR TITLE
fix: smoke tests to use node 18

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -27,7 +27,7 @@ jobs:
           pnpm link .
           pnpm link eslint-plugin-vitest
 
-      - uses: AriPerkkio/eslint-remote-tester-run-action@v3
+      - uses: AriPerkkio/eslint-remote-tester-run-action@v4
         with:
           issue-title: "Results of weekly scheduled smoke test"
           eslint-remote-tester-config: eslint-remote-tester.config.ts


### PR DESCRIPTION
- Fixes #243
- Fixes #241

The `||=` operator is not supported in Node 14. This PR updates `eslint-remote-tester-run-action` to v4 which runs on Node 18: https://github.com/AriPerkkio/eslint-remote-tester-run-action/releases/tag/v4