### PR TITLE
feat(consistent-test-it): rewrite import statement as well

### DIFF
--- a/tests/consistent-test-it.test.ts
+++ b/tests/consistent-test-it.test.ts
@@ -72,6 +72,12 @@ ruleTester.run(RULE_NAME, rule, {
           }
         }
       ]
+    },
+    {
+      code: 'import { test } from "vitest"\ntest("shows error", () => {});',
+      options: [{ fn: TestCaseName.it }],
+      output: 'import { it } from "vitest"\nit("shows error", () => {});',
+      errors: [{ messageId: 'consistentMethod' }, { messageId: 'consistentMethod' }]
     }
   ]
 })
@@ -259,6 +265,29 @@ ruleTester.run(RULE_NAME, rule, {
       output: 'test("foo")',
       options: [{ withinDescribe: TestCaseName.test }],
       errors: [
+        {
+          messageId: 'consistentMethod',
+          data: {
+            testFnKeyWork: TestCaseName.test,
+            oppositeTestKeyword: TestCaseName.it
+          }
+        }
+      ]
+    },
+    {
+      code: 'import { it } from "vitest"\nit("foo")',
+      output: 'import { test } from "vitest"\ntest("foo")',
+      options: [
+        { withinDescribe: TestCaseName.test }
+      ],
+      errors: [
+        {
+          messageId: 'consistentMethod',
+          data: {
+            testFnKeyWork: TestCaseName.test,
+            oppositeTestKeyword: TestCaseName.it
+          }
+        },
         {
           messageId: 'consistentMethod',
           data: {


### PR DESCRIPTION
When using explicit import from `vitest`, rewriting only `test()` to `it()` will cause the `test` not found error, and requires manually updating the imported named. This PR make it auto-fix as well. 