### PR TITLE
fix: export the "unbound-method" rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,26 @@ export default [
 | [require-top-level-describe](docs/rules/require-top-level-describe.md)       | Enforce that all tests are in a top-level describe                       |    | 🌐 |    |    |
 | [valid-describe-callback](docs/rules/valid-describe-callback.md)             | Enforce valid describe callback                                          | ✅  |    |    |    |
 | [valid-expect](docs/rules/valid-expect.md)                                   | Enforce valid `expect()` usage                                           | ✅  |    |    |    |
-| [valid-title](docs/rules/valid-title.md)                                     | Enforce valid titles                                                     | ✅  |    | 🔧 |    |
+
+#### Requires Type Checking
+
+| Name                                           | Description                                                  | 💼  | ⚠️  | 🔧  | 💡  | ❌  |
+| :--------------------------------------------- | :----------------------------------------------------------- | :-- | :-- | :-- | :-- | :-- |
+| [unbound-method](docs/rules/unbound-method.md) | Enforce unbound methods are called with their expected scope |     |     |     |     |     |
 
 <!-- end auto-generated rules list -->
+
+In order to use the rules powered by TypeScript type-checking, you must be using
+`@typescript-eslint/parser` & adjust your eslint config as outlined
+[here](https://typescript-eslint.io/linting/typed-linting).
+
+Note that unlike the type-checking rules in `@typescript-eslint/eslint-plugin`,
+the rules here will fallback to doing nothing if type information is not
+available, meaning it's safe to include them in shared configs that could be
+used on JavaScript and TypeScript projects.
+
+Also note that `unbound-method` depends on `@typescript-eslint/eslint-plugin`,
+as it extends the original `unbound-method` rule from that plugin.
 
 #### Credits
 

--- a/docs/rules/unbound-method.md
+++ b/docs/rules/unbound-method.md
@@ -6,7 +6,7 @@
 
 <!-- end auto-generated rule header -->
 
-This rule extends the base [`@typescript-eslint/unbound-method`][original-rule]
+This rule extends the base [`@typescript-eslint/unbound-method`][https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/unbound-method.md]
 rule, meaning you must depend on `@typescript-eslint/eslint-plugin` for it to
 work. It adds support for understanding when it's ok to pass an unbound method
 to `expect` calls.

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ import preferTodo, { RULE_NAME as preferTodoName } from './rules/prefer-todo'
 import preferSpyOn, { RULE_NAME as preferSpyOnName } from './rules/prefer-spy-on'
 import preferComparisonMatcher, { RULE_NAME as preferComparisonMatcherName } from './rules/prefer-comparison-matcher'
 import preferToContain, { RULE_NAME as preferToContainName } from './rules/prefer-to-contain'
-// import unboundMethod, { RULE_NAME as unboundMethodName } from './rules/unbound-method'
+import unboundMethod, { RULE_NAME as unboundMethodName } from './rules/unbound-method'
 
 const createConfig = (rules: Record<string, string>) => ({
 	plugins: ['vitest'],
@@ -165,8 +165,8 @@ export default {
 		[preferTodoName]: preferTodo,
 		[preferSpyOnName]: preferSpyOn,
 		[preferComparisonMatcherName]: preferComparisonMatcher,
-		[preferToContainName]: preferToContain
-		// [unboundMethodName]: unboundMethod
+		[preferToContainName]: preferToContain,
+		[unboundMethodName]: unboundMethod
 	},
 	configs: {
 		all: createConfig(allRules),

--- a/tests/unbound-method.test.ts
+++ b/tests/unbound-method.test.ts
@@ -32,7 +32,7 @@ ruleTester.run('unbound-method', unboundMethod, {
 		
 		logArrowBound();
 		logManualBind();`,
-      skip: true
+      skip: false
     }
   ],
   invalid: [
@@ -48,7 +48,7 @@ ruleTester.run('unbound-method', unboundMethod, {
 		
 		Promise.resolve().then(console.log);
 			  `,
-      skip: true,
+      skip: false,
       errors: [
         {
           line: 10,


### PR DESCRIPTION
Support for the `unbound-method` rule has been added in [#207](https://github.com/veritem/eslint-plugin-vitest/pull/207), but the rule was not exported, so it couldn't be used:

```
Definition for rule 'vitest/unbound-method' was not found. [vitest/unbound-method]
```

I assumed this was unintentional, since [the original issue about `unbound-method`](https://github.com/veritem/eslint-plugin-vitest/issues/171) was marked "Fixed" in the PR's description.

In this PR I uncommented the relevant lines, and completed the docs with info from the [`eslint-plugin-jest`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/unbound-method.md#requires-type-checking) repo.

Thank you for your work on this repo, and let me know if I have to change something! ☺️
