### PR TITLE
[expect-expect] Report of test identifier rather than body

### DIFF
--- a/src/rules/expect-expect.ts
+++ b/src/rules/expect-expect.ts
@@ -95,7 +95,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
 				}
 			},
 			'Program:exit'() {
-				unchecked.forEach(node => context.report({ node, messageId: 'expectedExpect', data: { expected: customExpressions.join(' or ') } }))
+				unchecked.forEach(node => context.report({ node: node.callee, messageId: 'expectedExpect', data: { expected: customExpressions.join(' or ') } }))
 			}
 		}
 	}


### PR DESCRIPTION
This is inspired by a fix that was recently merged into `eslint-plugin-jest` https://github.com/jest-community/eslint-plugin-jest/pull/1452 and released in 27.4.3 https://github.com/jest-community/eslint-plugin-jest/releases/tag/v27.4.3

## Issue

When writing tests (I often encounter this with Testing Library) where I do a large amount of setup / querying before I get to my first expectation my editor is essentially screaming at me for a while. I find this to be overly noisy where in reality I just want to make sure I don't commit an empty test case with this rule.

![CleanShot 2023-11-17 at 10 07 17](https://github.com/veritem/eslint-plugin-vitest/assets/782252/68516e49-713d-4367-8653-e74a4e582c87)

After this change, it instead only highlights the test identifier itself, which is much less distracting:

![CleanShot 2023-11-17 at 10 06 37](https://github.com/veritem/eslint-plugin-vitest/assets/782252/abd4e536-ae6e-4d61-a6c2-b155f7e2f107)
