### PR TITLE
fix(vitest/no-done-callback): do not report accessing of text context when test runs concurrently

### DIFF
--- a/src/rules/no-done-callback.ts
+++ b/src/rules/no-done-callback.ts
@@ -46,6 +46,9 @@ export default createEslintRule<Options, MessageIds>({
 				if (isVitestEach && node.callee.type !== AST_NODE_TYPES.TaggedTemplateExpression)
 					return
 
+				const isVitestConcurrent = getNodeName(node.callee)?.endsWith('.concurrent') ?? false;
+				if (isVitestConcurrent) return
+
 				const callback = findCallbackArg(node, isVitestEach, context)
 				const callbackArgIndex = Number(isVitestEach)
 

--- a/tests/no-done-callback.test.ts
+++ b/tests/no-done-callback.test.ts
@@ -13,6 +13,8 @@ ruleTester.run(RULE_NAME, rule, {
     'it.each``("something", ({ a, b }) => {})',
     'it.each([])("something", (a, b) => { a(); b(); })',
     'it.each``("something", ({ a, b }) => { a(); b(); })',
+    'it.concurrent("something", (context) => {})',
+    'it.concurrent("something", ({ expect }) => {})',
     'test("something", async function () {})',
     'test("something", someArg)',
     'beforeEach(() => {})',


### PR DESCRIPTION
Fixes #312 
