### PR TITLE
feat: new rule `no-import-node-test`

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ export default [
 | [no-focused-tests](docs/rules/no-focused-tests.md)                                                                       | Disallow focused tests                                                   |    | 🌐 | 🔧 |    |
 | [no-hooks](docs/rules/no-hooks.md)                                                                                       | Disallow setup and teardown hooks                                        |    | 🌐 |    |    |
 | [no-identical-title](docs/rules/no-identical-title.md)                                                                   | Disallow identical titles                                                | ✅  |    | 🔧 |    |
+| [no-import-node-test](docs/rules/no-import-node-test.md)                                                                 | Disallow importing `node:test`                                           |    | 🌐 | 🔧 |    |
 | [no-interpolation-in-snapshots](docs/rules/no-interpolation-in-snapshots.md)                                             | Disallow string interpolation in snapshots                               |    | 🌐 | 🔧 |    |
 | [no-large-snapshots](docs/rules/no-large-snapshots.md)                                                                   | Disallow large snapshots                                                 |    | 🌐 |    |    |
 | [no-mocks-import](docs/rules/no-mocks-import.md)                                                                         | Disallow importing from __mocks__ directory                              |    | 🌐 |    |    |

--- a/docs/rules/no-import-node-test.md
+++ b/docs/rules/no-import-node-test.md
@@ -2,6 +2,8 @@
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
 <!-- end auto-generated rule header -->
 
 ## Rule Details

--- a/docs/rules/no-import-node-test.md
+++ b/docs/rules/no-import-node-test.md
@@ -1,0 +1,30 @@
+# Disallow importing `node:test` (`vitest/no-import-node-test`)
+
+⚠️ This rule _warns_ in the 🌐 `all` config.
+
+<!-- end auto-generated rule header -->
+
+## Rule Details
+
+This rule warns when `node:test` is imported (usually accidentally). With `--fix`, it will replace the import with `vitest`.
+
+Examples of **incorrect** code for this rule:
+
+```ts
+import { test } from 'node:test'
+import { expect } from 'vitest'
+
+test('foo', () => {
+  expect(1).toBe(1)
+})
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+import { test, expect } from 'vitest'
+
+test('foo', () => {
+  expect(1).toBe(1)
+})
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,8 @@ import consistentTestFilename, { RULE_NAME as useConsistentTestFilename } from '
 import maxExpect, { RULE_NAME as maxExpectName } from './rules/max-expects'
 import noAliasMethod, { RULE_NAME as noAliasMethodName } from './rules/no-alias-methods'
 import noCommentedOutTests, { RULE_NAME as noCommentedOutTestsName } from './rules/no-commented-out-tests'
-import noConditonalExpect, { RULE_NAME as noConditonalExpectName } from './rules/no-conditional-expect'
+import noConditionalExpect, { RULE_NAME as noConditionalExpectName } from './rules/no-conditional-expect'
+import noImportNodeTest, { RULE_NAME as noImportNodeTestName } from './rules/no-import-node-test'
 import noConditionalInTest, { RULE_NAME as noConditionalInTestName } from './rules/no-conditional-in-test'
 import noDisabledTests, { RULE_NAME as noDisabledTestsName } from './rules/no-disabled-tests'
 import noDoneCallback, { RULE_NAME as noDoneCallbackName } from './rules/no-done-callback'
@@ -71,7 +72,7 @@ const allRules = {
 	[useConsistentTestFilename]: 'warn',
 	[maxExpectName]: 'warn',
 	[noAliasMethodName]: 'warn',
-	[noConditonalExpectName]: 'warn',
+	[noConditionalExpectName]: 'warn',
 	[noConditionalInTestName]: 'warn',
 	[noDisabledTestsName]: 'warn',
 	[noDoneCallbackName]: 'warn',
@@ -83,6 +84,7 @@ const allRules = {
 	[noStandaloneExpectName]: 'warn',
 	[noTestPrefixesName]: 'warn',
 	[noTestReturnStatementName]: 'warn',
+	[noImportNodeTestName]: 'warn',
 	[preferCalledWithName]: 'warn',
 	[preferToBeFalsyName]: 'warn',
 	[preferToBeObjectName]: 'warn',
@@ -134,7 +136,7 @@ export default {
 		[maxExpectName]: maxExpect,
 		[noAliasMethodName]: noAliasMethod,
 		[noCommentedOutTestsName]: noCommentedOutTests,
-		[noConditonalExpectName]: noConditonalExpect,
+		[noConditionalExpectName]: noConditionalExpect,
 		[noConditionalInTestName]: noConditionalInTest,
 		[noDisabledTestsName]: noDisabledTests,
 		[noDoneCallbackName]: noDoneCallback,
@@ -146,6 +148,7 @@ export default {
 		[noStandaloneExpectName]: noStandaloneExpect,
 		[noTestPrefixesName]: noTestPrefixes,
 		[noTestReturnStatementName]: noTestReturnStatement,
+		[noImportNodeTestName]: noImportNodeTest,
 		[preferCalledWithName]: preferCalledWith,
 		[validTitleName]: validTitle,
 		[validExpectName]: validExpect,

--- a/src/rules/no-import-node-test.ts
+++ b/src/rules/no-import-node-test.ts
@@ -8,7 +8,7 @@ export default createEslintRule<Options, MESSAGE_IDS>({
 	name: RULE_NAME,
 	meta: {
 		docs: {
-			description: 'Disallow importing from `node:test`, fix to `vitest` automatically',
+			description: 'Disallow importing `node:test`',
 			recommended: 'warn'
 		},
 		type: 'suggestion',

--- a/src/rules/no-import-node-test.ts
+++ b/src/rules/no-import-node-test.ts
@@ -1,0 +1,38 @@
+import { createEslintRule } from '../utils'
+
+export const RULE_NAME = 'no-import-node-test'
+export type MESSAGE_IDS = 'noImportNodeTest'
+export type Options = []
+
+export default createEslintRule<Options, MESSAGE_IDS>({
+	name: RULE_NAME,
+	meta: {
+		docs: {
+			description: 'Disallow importing from `node:test`, fix to `vitest` automatically',
+			recommended: 'warn'
+		},
+		type: 'suggestion',
+		messages: {
+			noImportNodeTest: 'Import from `vitest` instead of `node:test`'
+		},
+		fixable: 'code',
+		schema: []
+	},
+	defaultOptions: [],
+	create(context) {
+		return {
+			ImportDeclaration(node) {
+				if (node.source.value === 'node:test') {
+					context.report({
+						messageId: 'noImportNodeTest',
+						node,
+						fix: fixer => fixer.replaceText(
+							node.source,
+							node.source.raw.replace('node:test', 'vitest')
+						)
+					})
+				}
+			}
+		}
+	}
+})

--- a/tests/no-import-node-test.test.ts
+++ b/tests/no-import-node-test.test.ts
@@ -1,0 +1,20 @@
+import rule, { RULE_NAME } from '../src/rules/no-import-node-test'
+import { ruleTester } from './ruleTester'
+
+ruleTester.run(RULE_NAME, rule, {
+	valid: [
+		'import { test } from "vitest"'
+	],
+	invalid: [
+		{
+			code: 'import { test } from "node:test"',
+			output: 'import { test } from "vitest"',
+			errors: [{ messageId: 'noImportNodeTest' }]
+		},
+		{
+			code: 'import * as foo from \'node:test\'',
+			output: 'import * as foo from \'vitest\'',
+			errors: [{ messageId: 'noImportNodeTest' }]
+		}
+	]
+})


### PR DESCRIPTION
It was so annoying to me that VS Code often auto inserts the import from `node:test` when I type `describe` or `test`. It's might also hard to spot and found the bug. I think when ppl using Vitest, they are very unlikely to use `node:test` together. Having this rule allow the import to `node:test` always been fixed to `vitest`