### PR TITLE
fix(vitest/no-done-callback): do not report when inside concurrent describe

### DIFF
--- a/docs/rules/no-done-callback.md
+++ b/docs/rules/no-done-callback.md
@@ -56,4 +56,18 @@ test('foo', async () => {
 	resolve()
   }, 1000))
 })
+
+test.concurrent('foo', ({ expect }) => {
+  expect(1).toMatchSnapshot();
+});
+
+test.concurrent('foo', (context) => {
+  context.expect(1).toBe(1);
+});
+
+describe.concurrent('foo', () => {
+  test('foo', ({ expect }) => {
+    expect(1).toBe(1);
+  });
+});
 ```

--- a/tests/no-done-callback.test.ts
+++ b/tests/no-done-callback.test.ts
@@ -21,7 +21,9 @@ ruleTester.run(RULE_NAME, rule, {
     'beforeAll(async () => {})',
     'afterAll(() => {})',
     'afterAll(async function () {})',
-    'afterAll(async function () {}, 5)'
+    'afterAll(async function () {}, 5)',
+    'describe.concurrent("something", () => { it("something", ({ expect }) => { }) })',
+    'describe.concurrent("something", () => { it("something", context => { }) })'
   ],
   invalid: [
     {


### PR DESCRIPTION
## What?

I updated the rule to no report when the local Test Context is used inside a test that is inside a concurrent describe block. 

## Why?

The current implementation reported a false-positive when the scenario described above exists. 

## How?

The rule goes up its ancestors and checks if it's inside a concurrent test or describe block.

## Testing?

You can run the unit tests to check if the rule works. To check that on your local machine:
1. Active the rule (`vitest/no-done-callback`) 
2. Copy the following code snippet.

```js
import { describe, it } from 'vitest'; 

describe.concurrent('something', () => {
  it('something', ({ context }) => {
    expect(1).toBe(1);
  });
});
```

You will not see any linting error as long as the describe block has its `.concurrent` annotation. Once that gets removed the error will appear.