### PR TITLE
fix(vitest/require-local-test-context-for-concurrent-snapshots): report for all types of snapshot tests

### DIFF
--- a/src/rules/require-local-test-context-for-concurrent-snapshots.ts
+++ b/src/rules/require-local-test-context-for-concurrent-snapshots.ts
@@ -26,7 +26,10 @@ export default createEslintRule({
 
         const isNotASnapshotAssertion = ![
           'toMatchSnapshot',
-          'toMatchInlineSnapshot'
+          'toMatchInlineSnapshot',
+          'toMatchFileSnapshot',
+          'toThrowErrorMatchingSnapshot',
+          'toThrowErrorMatchingInlineSnapshot'
         ].includes(node.callee.property.name)
 
         if (isNotASnapshotAssertion) return

--- a/tests/require-local-test-context-for-concurrent-snapshots.test.ts
+++ b/tests/require-local-test-context-for-concurrent-snapshots.test.ts
@@ -53,6 +53,18 @@ ruleTester.run(RULE_NAME, rule, {
                  expect(true).toMatchSnapshot();
             })`,
             errors: [{ messageId: 'requireLocalTestContext' }]
-        }
+        },
+        {
+            code: 'it.concurrent("should fail", () => { expect(true).toMatchFileSnapshot("./test/basic.output.html") })',
+            errors: [{ messageId: 'requireLocalTestContext' }]
+        },
+        {
+            code: 'it.concurrent("should fail", () => { expect(foo()).toThrowErrorMatchingSnapshot() })',
+            errors: [{ messageId: 'requireLocalTestContext' }]
+        },
+        {
+            code: 'it.concurrent("should fail", () => { expect(foo()).toThrowErrorMatchingInlineSnapshot("bar") })',
+            errors: [{ messageId: 'requireLocalTestContext' }]
+        },
     ]
 })


### PR DESCRIPTION
## What?

The rule now reports any invalid snapshot assertion in concurrent tests. That is when they don't use the local Test Context

## Why?

It's required to use the local Test Context for every single type of snapshot tests.

## How?

I expanded the criteria for what is a snapshot assertion and what is not.

## Testing?

Run the unit tests to verify the new expected result. Follow these steps if you want to test it on your local machine:

Activate the rule `vitest/require-local-test-context-for-all-types-of-snapshot-tests`

Copy the code snippet below

```js
import { describe, expect } from 'vitest';

describe.concurrent("something", () => {
  it("something", () => {
    expect(() => {
      throw new Error('foo')
    }).toThrowErrorMatchingInlineSnapshot();
  });

  it("something", () => {
    expect("foo").toMatchFileSnapshot("./bar.txt");
  });
});

it("something", () => {
  expect(() => {
    throw new Error("foo");
  }).toThrowErrorMatchingSnapshot();
});
```

You will see that rule reported in three places.