### PR TITLE
feat: add support for expectTypeOf to expect-expect

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,22 @@ export default [
 ];
 ```
 
+#### Enabling with type-testing
+
+Vitest ships with an optional [type-testing feature](https://vitest.dev/guide/testing-types), which is disabled by default.
+
+If you're using this feature, you should also enabled `typecheck` in the settings for this plugin. This ensures that rules like [expect-expect](docs/rules/expect-expect.md) account for type-related assertions in tests.
+
+```json
+{
+  "extends": ["plugin:vitest/recommended"],
+  "settings" :{
+    "vitest": {
+      "typecheck": true,
+    }
+  }
+}
+```
 
 ### Rules
 

--- a/docs/rules/expect-expect.md
+++ b/docs/rules/expect-expect.md
@@ -28,6 +28,10 @@ test('myLogic', () => {
 })
 ```
 
+## Type-testing
+
+If you're using Vitest's [type-testing feature](https://vitest.dev/guide/testing-types) and have tests that only contain `expectTypeOf`, you will need to enable `typecheck` in this plugin's settings: [Enabling type-testing](../../README.md#enabling-with-type-testing).
+
 ## Options
 
 ### `assertFunctionNames`

--- a/src/utils/parsePluginSettings.ts
+++ b/src/utils/parsePluginSettings.ts
@@ -1,0 +1,20 @@
+import type { SharedConfigurationSettings } from '@typescript-eslint/utils/dist/ts-eslint'
+
+interface PluginSettings {
+    typecheck: boolean;
+}
+
+const DEFAULTS: PluginSettings = {
+    typecheck: false
+}
+
+export function parsePluginSettings(settings: SharedConfigurationSettings): PluginSettings {
+    const pluginSettings = typeof settings.vitest !== 'object' || settings.vitest === null
+        ? {}
+        : settings.vitest
+
+    return {
+        ...DEFAULTS,
+        ...pluginSettings
+    }
+}

--- a/tests/expect-expect.test.ts
+++ b/tests/expect-expect.test.ts
@@ -155,6 +155,14 @@ ruleTester.run(RULE_NAME, rule, {
 			`,
 			options: [{ assertFunctionNames: ['tester.foo.bar.expect'] }],
 			parserOptions: { sourceType: 'module' }
+		 },
+		 {
+			code: `
+			it("should pass with 'typecheck' enabled", () => {
+				expectTypeOf({ a: 1 }).toEqualTypeOf<{ a: number }>()
+			});
+			`,
+			settings: { vitest: { typecheck: true } }
 		 }
 	],
 	invalid: [
@@ -303,6 +311,19 @@ ruleTester.run(RULE_NAME, rule, {
 				messageId: 'noAssertions',
 				type: AST_NODE_TYPES.Identifier
 			}
+			]
+		 },
+		 {
+			code: `
+			it("should fail without 'typecheck' enabled", () => {
+				expectTypeOf({ a: 1 }).toEqualTypeOf<{ a: number }>()
+			});
+			`,
+			errors: [
+				{
+					messageId: 'noAssertions',
+					type: AST_NODE_TYPES.Identifier
+				}
 			]
 		 }
 	]


### PR DESCRIPTION
As type-checking can be enabled via `--typecheck` or `typecheck.enabled` in `vitest.config.ts`, it felt better to make this an opt-in - like the type-testing feature is.

With this approach, other rules can also handle type-testing with the new setting.

Fixes #382.

