### PR TITLE
fix: support ESLint v9 getScope()

### DIFF
--- a/src/rules/no-disabled-tests.ts
+++ b/src/rules/no-disabled-tests.ts
@@ -69,7 +69,11 @@ export default createEslintRule<Options, MESSAGE_ID>({
                     testDepth--
             },
             'CallExpression[callee.name="pending"]'(node) {
-                if (resolveScope(context.getScope(), 'pending'))
+                const scope = context.sourceCode.getScope
+                    ? context.sourceCode.getScope(node)
+                    : context.getScope()
+
+                if (resolveScope(scope, 'pending'))
                     return
 
                 if (testDepth > 0)

--- a/src/utils/parseVitestFnCall.ts
+++ b/src/utils/parseVitestFnCall.ts
@@ -242,7 +242,7 @@ const parseVitestFnCallWithReasonInner = (
     if (node.callee.type === AST_NODE_TYPES.TaggedTemplateExpression && lastLink !== 'each')
         return null
 
-    const resolved = resolveVitestFn(context, getAccessorValue(first))
+    const resolved = resolveVitestFn(context, node, getAccessorValue(first))
 
     if (!resolved)
         return null
@@ -316,9 +316,13 @@ interface ResolvedVitestFnType {
 
 const resolveVitestFn = (
     context: TSESLint.RuleContext<string, unknown[]>,
+    node: TSESTree.Node,
     identifier: string
 ): ResolvedVitestFnType | null => {
-    const maybeImport = resolveScope(context.getScope(), identifier)
+    const scope = context.sourceCode.getScope
+        ? context.sourceCode.getScope(node)
+        : context.getScope()
+    const maybeImport = resolveScope(scope, identifier)
 
     if (maybeImport === 'local')
         return null


### PR DESCRIPTION
https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/#context.getscope()