### PR TITLE
fix(rules): replace `context` deprecations

### DIFF
--- a/src/rules/consistent-test-filename.ts
+++ b/src/rules/consistent-test-filename.ts
@@ -51,7 +51,7 @@ export default createEslintRule<
         const pattern = typeof patternRaw === 'string' ? new RegExp(patternRaw) : patternRaw
         const testPattern = typeof allTestPatternRaw === 'string' ? new RegExp(allTestPatternRaw) : allTestPatternRaw
 
-        const filename = path.basename(context.getFilename())
+        const filename = path.basename(context.filename)
         if (!testPattern.test(filename))
             return {}
 

--- a/src/rules/expect-expect.ts
+++ b/src/rules/expect-expect.ts
@@ -72,7 +72,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
 				const index = node.type === AST_NODE_TYPES.CallExpression ? unchecked.indexOf(node) : -1
 
 				if (node.type === AST_NODE_TYPES.FunctionDeclaration) {
-					const declaredVariables = context.getDeclaredVariables(node)
+					const declaredVariables = context.sourceCode.getDeclaredVariables(node)
 					const testCallExpressions = getTestCallExpressionsFromDeclaredVariables(declaredVariables, context)
 
 					checkCallExpression(testCallExpressions)
@@ -100,7 +100,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
 
 					unchecked.push(node)
 				} else if (matchesAssertFunctionName(name, assertFunctionNames)) {
-					checkCallExpression(context.getAncestors())
+					checkCallExpression(context.sourceCode.getAncestors(node))
 				}
 			},
 			'Program:exit'() {

--- a/src/rules/no-commented-out-tests.ts
+++ b/src/rules/no-commented-out-tests.ts
@@ -25,7 +25,7 @@ export default createEslintRule<Options, MESSAGE_IDS>({
     },
     defaultOptions: [],
     create(context) {
-        const sourceCode = context.getSourceCode()
+        const { sourceCode } = context
 
         function checkNodeForCommentedOutTests(node: TSESTree.Comment) {
             if (!hasTests(node))

--- a/src/rules/no-conditional-expect.ts
+++ b/src/rules/no-conditional-expect.ts
@@ -37,7 +37,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
 
         return {
             FunctionDeclaration(node) {
-                const declaredVariables = context.getDeclaredVariables(node)
+                const declaredVariables = context.sourceCode.getDeclaredVariables(node)
                 const testCallExpressions = getTestCallExpressionsFromDeclaredVariables(declaredVariables, context)
 
                 if (testCallExpressions.length > 0)

--- a/src/rules/no-done-callback.ts
+++ b/src/rules/no-done-callback.ts
@@ -47,7 +47,7 @@ export default createEslintRule<Options, MessageIds>({
                 if (isVitestEach && node.callee.type !== AST_NODE_TYPES.TaggedTemplateExpression)
                     return
 
-                const isInsideConcurrentTestOrDescribe = context.getAncestors().some((ancestor) => {
+                const isInsideConcurrentTestOrDescribe = context.sourceCode.getAncestors(node).some((ancestor) => {
                     if (ancestor.type !== AST_NODE_TYPES.CallExpression) return false
 
                     const isNotInsideDescribeOrTest = !isTypeOfVitestFnCall(ancestor, context, ['describe', 'test'])
@@ -97,7 +97,7 @@ export default createEslintRule<Options, MessageIds>({
                             fix(fixer) {
                                 const { body, params } = callback
 
-                                const sourceCode = context.getSourceCode()
+                                const { sourceCode } = context
                                 const firstBodyToken = sourceCode.getFirstToken(body)
                                 const lastBodyToken = sourceCode.getLastToken(body)
 
@@ -114,7 +114,7 @@ export default createEslintRule<Options, MessageIds>({
                                     !lastBodyToken ||
                                     !tokenBeforeFirstParam ||
                                     !tokenAfterLastParam)
-                                    throw new Error(`Unexpected null when attempting to fix ${context.getFilename()} - please file an issue at https://github/veritem/eslint-plugin-vitest`)
+                                    throw new Error(`Unexpected null when attempting to fix ${context.filename} - please file an issue at https://github/veritem/eslint-plugin-vitest`)
 
                                 let argumentFix = fixer.replaceText(firstParam, '()')
 

--- a/src/rules/no-large-snapshots.ts
+++ b/src/rules/no-large-snapshots.ts
@@ -33,7 +33,7 @@ const reportOnViolation = (
         node.expression.left.type === AST_NODE_TYPES.MemberExpression &&
         isSupportedAccessor(node.expression.left.property)
     ) {
-        const fileName = context.getFilename()
+        const fileName = context.filename
         const allowedSnapshotsInFile = allowedSnapshots[fileName]
 
         if (allowedSnapshotsInFile) {
@@ -93,7 +93,7 @@ export default createEslintRule<[RuleOptions], MESSAGE_IDS>({
     },
     defaultOptions: [{}],
     create(context, [options]) {
-        if (context.getFilename().endsWith('.snap')) {
+        if (context.filename.endsWith('.snap')) {
             return {
                 ExpressionStatement(node) {
                     reportOnViolation(context, node, options)

--- a/src/rules/no-test-return-statement.ts
+++ b/src/rules/no-test-return-statement.ts
@@ -42,7 +42,7 @@ export default createEslintRule<Options, MessageIds>({
                 context.report({ messageId: 'noTestReturnStatement', node: returnStmt })
             },
             FunctionDeclaration(node) {
-                const declaredVariables = context.getDeclaredVariables(node)
+                const declaredVariables = context.sourceCode.getDeclaredVariables(node)
                 const testCallExpressions = getTestCallExpressionsFromDeclaredVariables(declaredVariables, context)
 
                 if (testCallExpressions.length === 0) return

--- a/src/rules/prefer-comparison-matcher.ts
+++ b/src/rules/prefer-comparison-matcher.ts
@@ -98,7 +98,7 @@ export default createEslintRule<Options, MESSAGE_IDS>({
 
                 context.report({
                     fix(fixer) {
-                        const sourceCode = context.getSourceCode()
+                        const { sourceCode } = context
 
                         const modifierText =
                             modifier && getAccessorValue(modifier) !== 'not'

--- a/src/rules/prefer-equality-matcher.ts
+++ b/src/rules/prefer-equality-matcher.ts
@@ -66,7 +66,7 @@ export default createEslintRule<Options, MESSAGE_IDS>({
                 const addNotModifier = (comparison.operator === '!==' ? !matcherValue : matcherValue) === hasNot
 
                 const buildFixer = (equalityMatcher: string): TSESLint.ReportFixFunction => fixer => {
-                    const sourceCode = context.getSourceCode()
+                    const { sourceCode } = context
 
                     let modifierText = modifier && getAccessorValue(modifier) !== 'not' ? `.${getAccessorValue(modifier)}` : ''
 

--- a/src/rules/prefer-mock-promise-shorthand.ts
+++ b/src/rules/prefer-mock-promise-shorthand.ts
@@ -57,7 +57,7 @@ export default createEslintRule<Options, MESSAGE_IDS>({
                 messageId: 'useMockShorthand',
                 data: { replacement },
                 fix(fixer) {
-                    const sourceCode = context.getSourceCode()
+                    const { sourceCode } = context
 
                     if (innerArgNode.arguments.length > 1)
                         return null

--- a/src/rules/prefer-spy-on.ts
+++ b/src/rules/prefer-spy-on.ts
@@ -52,7 +52,7 @@ const getAutoFixMockImplementation = (
         return ''
 
     const [arg] = vitestFnCall.arguments
-    const argSource = arg && context.getSourceCode().getText(arg)
+    const argSource = arg && context.sourceCode.getText(arg)
 
     return argSource
         ? `.mockImplementation(${argSource})`

--- a/src/rules/prefer-to-contain.ts
+++ b/src/rules/prefer-to-contain.ts
@@ -66,7 +66,7 @@ export default createEslintRule<Options, MESSAGE_IDS>({
 
                 context.report({
                     fix(fixer) {
-                        const sourceCode = context.getSourceCode()
+                        const { sourceCode } = context
 
                         const addNotModifier = matcherArg.value === hasNot
 

--- a/src/rules/require-local-test-context-for-concurrent-snapshots.ts
+++ b/src/rules/require-local-test-context-for-concurrent-snapshots.ts
@@ -34,7 +34,7 @@ export default createEslintRule({
 
         if (isNotASnapshotAssertion) return
 
-        const isInsideSequentialDescribeOrTest = !context.getAncestors().some((ancestor) => {
+        const isInsideSequentialDescribeOrTest = !context.sourceCode.getAncestors(node).some((ancestor) => {
           if (ancestor.type !== AST_NODE_TYPES.CallExpression) return false
 
           const isNotInsideDescribeOrTest = !isTypeOfVitestFnCall(ancestor, context, ['describe', 'test'])

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -181,7 +181,7 @@ export const removeExtraArgumentsFixer = (
   const firstArg = func.arguments[from]
   const lastArg = func.arguments[func.arguments.length - 1]
 
-  const sourceCode = context.getSourceCode()
+  const { sourceCode } = context
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   let tokenAfterLastParam = sourceCode.getTokenAfter(lastArg)!


### PR DESCRIPTION
Fixes #413 by replacing all the `context` methods which have been deprecated in eslint v8, and subsequently removed in v9 or are slated for removal in v10 (outlined in [this blog post](https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/#main)). 

The supported `eslint` versions all have the new syntax: 
https://github.com/veritem/eslint-plugin-vitest/blob/76f00f604308e3ad3cd5fe3bdd302a1262b6ee1f/package.json#L70
Therefore it's safe to use the replacement methods directly, without a fallback to the old methods (which they showcase in the blog post for backwards compatibility).