### PR TITLE
fix(no-focused-tests): support .each template strings

### DIFF
--- a/src/rules/no-focused-tests.ts
+++ b/src/rules/no-focused-tests.ts
@@ -43,6 +43,22 @@ export default createEslintRule<Options, MessageIds>({
               messageId: 'noFocusedTests'
             })
           }
+
+          if (callee.type === 'TaggedTemplateExpression') {
+            const tagCall = callee.tag.type === 'MemberExpression' ? callee.tag.object : null
+            if (!tagCall) return
+
+            if (
+              tagCall.type === 'MemberExpression' &&
+              isTestOrDescribe(tagCall.object) &&
+              isOnly(tagCall.property)
+            ) {
+              context.report({
+                node: tagCall.property,
+                messageId: 'noFocusedTests'
+              })
+            }
+          }
         }
       },
       CallExpression(node) {

--- a/tests/no-focused-tests.test.ts
+++ b/tests/no-focused-tests.test.ts
@@ -56,6 +56,32 @@ ruleTester.run(RULE_NAME, rule, {
         }
       ],
       output: 'it.only.each([])("test", () => {});'
+    },
+    {
+      code: 'test.only.each``("test", () => {});',
+      errors: [
+        {
+          column: 6,
+          endColumn: 10,
+          endLine: 1,
+          line: 1,
+          messageId: 'noFocusedTests'
+        }
+      ],
+      output: 'test.only.each``("test", () => {});'
+    },
+    {
+      code: 'it.only.each``("test", () => {});',
+      errors: [
+        {
+          column: 4,
+          endColumn: 8,
+          endLine: 1,
+          line: 1,
+          messageId: 'noFocusedTests'
+        }
+      ],
+      output: 'it.only.each``("test", () => {});'
     }
   ]
 })


### PR DESCRIPTION
Fixes #

adds support for [test.each](https://vitest.dev/api/#test-each) with template literals

---
changes tested locally also in a separate repo

![CleanShot 2024-04-09 at 1  20 25](https://github.com/veritem/eslint-plugin-vitest/assets/68335961/df28a096-166e-42b3-9fb3-cdefccde1430)
