### PR TITLE
fix: configs in plugin declaration file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,8 +60,8 @@ const createConfig = <R extends Linter.RulesRecord>(rules: R) => (
       [`vitest/${ruleName}`]: rules[ruleName]
     }
   }, {})) as {
-    [K in keyof R as `vitest/${Extract<K, string>}`]: R[K]
-  }
+  [K in keyof R as `vitest/${Extract<K, string>}`]: R[K]
+}
 
 const allRules = {
   [lowerCaseTitleName]: 'warn',
@@ -185,7 +185,7 @@ const plugin = {
       plugins: {
         get vitest(): ESLint.Plugin {
           return plugin
-        },
+        }
       },
       rules: createConfig(recommended)
     },
@@ -193,7 +193,7 @@ const plugin = {
       plugins: {
         get vitest(): ESLint.Plugin {
           return plugin
-        },
+        }
       },
       rules: createConfig(allRules)
     },


### PR DESCRIPTION
Fixes #427 

This also fixes the globals values of `env` config. It was previously `writeable` but the correct is `writable` (all though I don't understand why it's specified as writable in the first place). This was not type checked previously since there are no type constraints with `Object.assign`.

Side note: I'm noticing that the CI pipeline don't typecheck the code. `pnpm tsc` fails on main for me.