### PR TITLE
fix: `require` in ESM

### DIFF
--- a/src/utils/ast-utils.ts
+++ b/src/utils/ast-utils.ts
@@ -1,6 +1,7 @@
 import { AST_NODE_TYPES, AST_TOKEN_TYPES, TSESLint, TSESTree } from "@typescript-eslint/utils";
 import { createRequire } from "node:module"
 
+const require = createRequire(import.meta.url)
 const eslintRequire = createRequire(require.resolve("eslint"))
 
 export const espreeParser = eslintRequire.resolve('espree');


### PR DESCRIPTION
There's `require.resolve()` call in `.mjs` file. 

https://github.com/veritem/eslint-plugin-vitest/blob/d74b09b552372daeb8f2f1d1583c1a194bd1f210/src/utils/ast-utils.ts#L4

Ran into this issue while fixing other problem in the codebase.

```bash
$ pnpm build; node dist/index.mjs 

> eslint-plugin-vitest@0.6.0 build /<root>/eslint-plugin-vitest
> unbuild

ℹ Automatically detected entries: src/index [esm] [cjs] [dts]            3:33:18 PM
ℹ Building eslint-plugin-vitest                                          3:33:18 PM
ℹ Cleaning dist directory: ./dist                                        3:33:18 PM
✔ Build succeeded for eslint-plugin-vitest                               3:33:20 PM
[3:33:20 PM]   dist/index.cjs (total size: 192 kB, chunk size: 192 kB, exports: default)

[3:33:20 PM]   dist/index.mjs (total size: 189 kB, chunk size: 189 kB, exports: default)

Σ Total dist size (byte size): 406 kB
                                                                          3:33:20 PM
file:///<root>/eslint-plugin-vitest/dist/index.mjs:4015
const eslintRequire = createRequire(require.resolve("eslint"));
                                    ^

ReferenceError: require is not defined in ES module scope, you can use import instead
    at file:///<root>/eslint-plugin-vitest/dist/index.mjs:4015:37
    at ModuleJob.run (node:internal/modules/esm/module_job:222:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:316:24)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:123:5)

Node.js v20.13.1
```

With the fix:

```bash
ari ~/Git/eslint-plugin-vitest (fix/esm-require) $ pnpm build; node dist/index.mjs 

> eslint-plugin-vitest@0.6.0 build /<root>/eslint-plugin-vitest
> unbuild

ℹ Automatically detected entries: src/index [esm] [cjs] [dts]            3:37:10 PM
ℹ Building eslint-plugin-vitest                                          3:37:10 PM
ℹ Cleaning dist directory: ./dist                                        3:37:10 PM
✔ Build succeeded for eslint-plugin-vitest                               3:37:12 PM
[3:37:12 PM]   dist/index.cjs (total size: 192 kB, chunk size: 192 kB, exports: default)

[3:37:12 PM]   dist/index.mjs (total size: 189 kB, chunk size: 189 kB, exports: default)

Σ Total dist size (byte size): 406 kB
                                                                          3:37:12 PM
ari ~/Git/eslint-plugin-vitest (fix/esm-require) $ node dist/index.mjs 
# OK
```