### PR TITLE
test: fix smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
 
       - uses: pnpm/action-setup@v3
         with:
-          version: 8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -9,11 +9,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v3
         with:
-          version: 7.16.1
+          run_install: false
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -20,12 +20,13 @@ jobs:
           node-version: 18.x
           cache: pnpm
 
-      - name: Install, Build & Link plugin
+      - name: Install, Build
         run: |
           pnpm install
           pnpm build
-          pnpm link .
-          pnpm link eslint-plugin-vitest
+
+      - name: Update ESLint to v9
+        run: pnpm i -D eslint@9
 
       - uses: AriPerkkio/eslint-remote-tester-run-action@v5
         with:

--- a/eslint-remote-tester.config.ts
+++ b/eslint-remote-tester.config.ts
@@ -1,10 +1,24 @@
-import vitest from "eslint-plugin-vitest"
+import parser from '@typescript-eslint/parser';
+import type { Config } from 'eslint-remote-tester';
+import {
+  getPathIgnorePattern,
+  getRepositories,
+} from 'eslint-remote-tester-repositories';
+import vitest from './dist/index.mjs';
 
 export default {
-  repositories: ['AriPerkkio/eslint-remote-tester-integration-test-target'],
+  repositories: getRepositories(),
+  pathIgnorePattern: getPathIgnorePattern(),
   extensions: ['ts', 'tsx', 'cts', 'mts'],
   concurrentTasks: 3,
   cache: false,
   logLevel: 'info',
-  eslintConfig: [vitest.configs.all]
-}
+  eslintConfig: [
+    vitest.configs.all,
+    {
+      languageOptions: {
+        parser,
+      },
+    },
+  ] as Config['eslintConfig'],
+} satisfies Config;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 	"files": [
 		"dist"
 	],
+  "packageManager": "pnpm@9.3.0",
 	"scripts": {
 		"build": "unbuild",
 		"lint:eslint-docs": "pnpm build && eslint-doc-generator --check",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 		"eslint-plugin-eslint-plugin": "^6.1.0",
 		"eslint-plugin-vitest": "^0.5.4",
 		"eslint-remote-tester": "^4.0.0",
-		"eslint-remote-tester-repositories": "^1.0.1",
+    "eslint-remote-tester-repositories": "^2.0.0",
 		"importx": "^0.3.5",
 		"tsx": "^4.10.5",
 		"typescript": "^5.4.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,8 +58,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0(eslint@8.57.0)(importx@0.3.5)(jiti@1.21.0)
       eslint-remote-tester-repositories:
-        specifier: ^1.0.1
-        version: 1.0.1
+        specifier: ^2.0.0
+        version: 2.0.0
       importx:
         specifier: ^0.3.5
         version: 0.3.5
@@ -1592,8 +1592,9 @@ packages:
       vitest:
         optional: true
 
-  eslint-remote-tester-repositories@1.0.1:
-    resolution: {integrity: sha512-XL9PqGBDL4rORnQ74b/3tqbJUpMlPz9gzKSrmYFtakLBQ/ayBELB/HZvd6ZEl+mH0vBeSYtUH7E/rawBsf9Qzg==}
+  eslint-remote-tester-repositories@2.0.0:
+    resolution: {integrity: sha512-BRMINT2nB6A7IJ08Kz4p7By9/Ru8D6yl4LAfjkDpFuKoX6Y25QEUyhgo8THh1GiTKWDP+RsYsGh2etmAP/v+lg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
 
   eslint-remote-tester@4.0.0:
     resolution: {integrity: sha512-Lmb0I9tYMQNtNHN8tYTzk755PeDa/wToBJ1x8QuSBHdFl8+X4BcRRJMLlEdsyOe4urxbm/NeUKYo/Nw6gJxMgw==}
@@ -5054,7 +5055,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-remote-tester-repositories@1.0.1: {}
+  eslint-remote-tester-repositories@2.0.0: {}
 
   eslint-remote-tester@4.0.0(eslint@8.57.0)(importx@0.3.5)(jiti@1.21.0):
     dependencies:

--- a/src/utils/ast-utils.ts
+++ b/src/utils/ast-utils.ts
@@ -1,6 +1,7 @@
 import { AST_NODE_TYPES, AST_TOKEN_TYPES, TSESLint, TSESTree } from "@typescript-eslint/utils";
 import { createRequire } from "node:module"
 
+const require = createRequire(import.meta.url)
 const eslintRequire = createRequire(require.resolve("eslint"))
 
 export const espreeParser = eslintRequire.resolve('espree');


### PR DESCRIPTION
Continues work from https://github.com/veritem/eslint-plugin-vitest/pull/470, with fix applied from https://github.com/veritem/eslint-plugin-vitest/pull/473.

Example run: https://github.com/AriPerkkio/eslint-plugin-vitest/actions/runs/9482770552/job/26128361215

- chore: set `packageManager`
  - Lockfile seems to be generated with `pnpm@9`, but CIs are using `pnpm@8`
  - Contributors may end up re-generating whole lockfile if the version doesn't match with expected major

- test: fix smoke tests
  - Run tests against 10K repositories from `eslint-remote-tester-repositories`, instead of just a single one
  - Use required peer dependency `eslint@9` - the Node API of `eslint@8` is not compatible with required version 9. I wonder why there's no warning from `peerDependencies` conflict 🤔 

