### PR TITLE
fix(bench): avoid bench being recognized consistent-test-it rule

### DIFF
--- a/src/rules/consistent-test-it.ts
+++ b/src/rules/consistent-test-it.ts
@@ -117,6 +117,8 @@ export default createEslintRule<
         }
       },
       CallExpression(node: TSESTree.CallExpression) {
+        if (node.callee.type === AST_NODE_TYPES.Identifier && node.callee.name === 'bench')
+          return
         const vitestFnCall = parseVitestFnCall(node, context)
 
         if (!vitestFnCall) return

--- a/tests/consistent-test-it.test.ts
+++ b/tests/consistent-test-it.test.ts
@@ -22,7 +22,13 @@ ruleTester.run(RULE_NAME, rule, {
   });
   function myTest() { if ('bar') {} }`,
       options: [{ fn: TestCaseName.it }]
-    }
+    },
+    {
+      code: `bench("foo", function () {
+        fibonacci(10);
+     })`,
+      options: [{ fn: TestCaseName.it }]
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
This PR fixes so that `bench` doesn't get recognized by the `consistent-test-it` rule.