### PR TITLE
Improved The Documentation

### DIFF
--- a/docs/rules/prefer-expect-resolves.md
+++ b/docs/rules/prefer-expect-resolves.md
@@ -13,4 +13,3 @@ it('passes', async () => { expect(await someValue()).toBe(true); });
 // good 
 it('passes', async () => { await expect(someValue()).resolves.toBe(true); });
 ```
-```


### PR DESCRIPTION
Fixes #
Removed the redundant code block start (` ``` `) which caused GitHub to add an empty code block at the end of the markdown preview in <ins>prefer-expect-resolves.md</ins>.