### PR TITLE
Avoid test.extend in expect-expect throwing a false positive.

### DIFF
--- a/src/rules/expect-expect.ts
+++ b/src/rules/expect-expect.ts
@@ -90,6 +90,9 @@ export default createEslintRule<Options, MESSAGE_ID>({
         if (node.callee.type === AST_NODE_TYPES.Identifier && node.callee.name === 'bench')
           return
 
+        if (node?.callee?.type === AST_NODE_TYPES.MemberExpression && node.callee.property.type === AST_NODE_TYPES.Identifier && node.callee.property.name === 'extend')
+          return
+
         if (node?.callee?.type === AST_NODE_TYPES.MemberExpression && node.callee.property.type === AST_NODE_TYPES.Identifier && node.callee.property.name === 'skip')
           return
 

--- a/tests/expect-expect.test.ts
+++ b/tests/expect-expect.test.ts
@@ -175,6 +175,45 @@ ruleTester.run(RULE_NAME, rule, {
    });
    `,
       settings: { vitest: { typecheck: true } }
+    },
+    {
+      code: `
+    it.extend({ 
+      theForce: async ({}, use) => { await use("Space Magic") },
+      luke: async ({first}, use) => { await use(theForce) } 
+    })
+    `,
+      name: "should allow it.extend"
+    },
+    {
+      code: `
+    async function theForce ({}, use) { await use("Space Magic") }
+    const luke = async ({first}, use) => { await use(theForce) }; 
+    const testOfStrength = it.extend({ theForce, luke });
+    `,
+      name: "should allow it.extend with extracted fixtures"
+    },
+    {
+      code: `
+    const myTest = base.extend({
+      fixture: [
+        async ({}, use) => {
+          // this function will run
+          setup()
+          await use()
+          teardown()
+        },
+        { auto: true } // Mark as an automatic fixture
+      ],
+    })
+    myTest("should pass this", ()=>{
+      expect(true).toBe(true);
+    })
+      `,
+      options: [{
+        "additionalTestBlockFunctions":[ "myTest"],
+        "assertFunctionNames": ["expect"]
+      }]
     }
   ],
   invalid: [

--- a/tests/expect-expect.test.ts
+++ b/tests/expect-expect.test.ts
@@ -203,7 +203,7 @@ ruleTester.run(RULE_NAME, rule, {
           await use()
           teardown()
         },
-        { auto: true } // Mark as an automatic fixture
+        { auto: true }
       ],
     })
     myTest("should pass this", ()=>{
@@ -355,7 +355,6 @@ ruleTester.run(RULE_NAME, rule, {
     // ...
    });
    `,
-      options: [{ assertFunctionNames: ['expect', 'foo'] }],
       parserOptions: { sourceType: 'module' },
       errors: [
         {
@@ -370,6 +369,33 @@ ruleTester.run(RULE_NAME, rule, {
     expectTypeOf({ a: 1 }).toEqualTypeOf<{ a: number }>()
    });
    `,
+      errors: [
+        {
+          messageId: 'noAssertions',
+          type: AST_NODE_TYPES.Identifier
+        }
+      ]
+    },
+    {
+      code: `
+    import { it } from 'vitest';
+    const myExtendedTest = it.extend({
+      fixture: [
+        async ({}, use) => {
+          // this function will run
+          setup()
+          await use()
+          teardown()
+        },
+        { auto: true }
+      ],
+    })
+    myExtendedTest("should still fail when using the extended test", ()=> {
+      // ...
+    })
+      `,
+      options: [{ additionalTestBlockFunctions: ['myExtendedTest'] }], 
+      parserOptions: { sourceType: 'module' },
       errors: [
         {
           messageId: 'noAssertions',


### PR DESCRIPTION
Fixes a false positive when using the 'extend' features of the test context. This is my first commit to the eslint plugin system so let me know if I've gotten anything wrong about how to approach the tests etc.

![image](https://github.com/user-attachments/assets/9631e805-08d7-49a6-b164-933fec46a35b) 